### PR TITLE
Update/now page

### DIFF
--- a/.markdownlint-cli2.yaml
+++ b/.markdownlint-cli2.yaml
@@ -1,0 +1,2 @@
+config:
+  no-bare-urls: false

--- a/site/content/posts/2025/updates/index.md
+++ b/site/content/posts/2025/updates/index.md
@@ -1,0 +1,39 @@
+---
+title: "Updates"
+date: 2025-06-10T20:59:50Z
+draft: true
+tags:
+  - meta
+  - blog
+  - indieweb
+categories:
+  - personal
+thumbnailAlt:
+metaAlignment: left
+summary: Updates to my website and thoughts on what to do next.
+---
+
+I've been a bit more active on my website lately, and I wanted to document a bit of what I've done and what I've been thinking about. Something about moving has me thinking more about documenting my experiences--especially in photographs--and sharing that with others (Rachel has said something similar about her website). I hope to spend more time doing things I enjoy, especially outside, and photography is something that Rachel and I enjoy doing together. This change in our lives is one of simplification and decluttering; perhaps I can simplify my engagement with the internet in a similar way.
+
+## Website Updates
+
+### Infrastructure
+
+I've configured a CDN sharing content from object storage, which should be a very efficient way to share high resolution images. I actually had this partially configured previously, but I've now setup URL rewrites in a way that I like and have fully tested it.
+
+<!-- prettier-ignore -->
+{{< figure
+    src="https://cdn.bckr.me/img/NGC3344_hst1024.jpg"
+    alt="NASA Astronomy photo of the day of NGC 3344, a spiral galaxy in the constellation Leo Minor."
+    caption="[APOD image of NGC 3344](https://apod.nasa.gov/apod/2506) served via the CDN"
+    >}}
+
+Right now, I just have some testing images (and a huge collection of [88x31 buttons](https://cdn.bckr.me/bin/hellnet_8831_buttons_nodupes.zip) :grin:) are in there currently, but if I find myself with a need to distribute data at scale, I'll be ready for it. If nothing else, I can share any photos I take at full resolution. If I do actually share a lot of photos, I'll probably need to build out some shortcodes to make that easier. The theme I use, Congo, supplies a versatile `figure` shortcode, but I'll need a way to handle carousels.
+
+### Pages
+
+I made some updates and additions to my slash pages. I updated my [/now]({{< relref "now" >}}) page to include some information about my [reading]({{< relref "now#reading" >}}) and slightly revised the bit about [moving]({{< relref "now#moving-to-puerto-rico" >}}). I also added a [/chipotle]({{< relref "chipotle" >}}) page which, despite the name, includes more than _just_ my Chipotle order. I hope I get the chance to use it, but it's a neat idea regardless. I added my Subway order as well, and am considering adding checkable checkboxes to make it a bit easier to use.
+
+### Upcoming
+
+I'd like to circle back around on my webmentions and indieweb features. I've built out a small number of shortcodes, that mostly just wrap content in a `span` with an appropriate type, but it's an okay foundation. Next, I'd like to work on recieving and sending webmentions. There's quite a bit of prior art out there for fetching and displaying webmentions for me to learn from. I'm already configured for recieving the mentions, but I don't have a way to display them yet. I intend to fetch the webmentions, store them as data in the repo, and then display them on the page. I like this solution because it will allow me to serve the mentions directly and avoid unnecessary 3rd party references on my site.

--- a/site/content/slashes/chipotle/index.md
+++ b/site/content/slashes/chipotle/index.md
@@ -1,0 +1,45 @@
+---
+title: "Chipotle"
+date: 2025-06-08T08:49:24-04:00
+draft: false
+url: chipotle
+menus: Slashes
+summary: My preferred orders at Chipotle and other restaurants. A handy reference for when I forget what I like.
+weight: 30
+showTableOfContents: true
+showAuthor: false
+sharingLinks: false
+invertPagination: true
+---
+
+My [Chipotle](https://slashpages.net/#chipotle) page documents my preferred orders at Chipotle and other restaurants. Never again will I be cursed with typing out 'fajita vegetables'. "What do I want on my burrito?" I want it all, Jasper; I want love. But sour cream will do.
+
+## Chipotle
+
+Burrito or Bowl
+
+- Brown rice
+- Black beans
+- Fajita vegetables
+- Chicken (or special)
+- Tomato salsa
+- Hot salsa
+- Sour cream
+- Cheese
+- Chips and salsa (optional)
+
+---
+
+## Subway
+
+Spicy Italian or BMT
+
+- Wheat bread
+- Provolone cheese
+- Toast it!
+- Spinach
+- Cucumber
+- Pickles
+- Olives
+- Banana peppers
+- Italian dressing

--- a/site/content/slashes/now/index.md
+++ b/site/content/slashes/now/index.md
@@ -16,8 +16,18 @@ invertPagination: true
 
 ### Moving to Puerto Rico
 
-My main project right now, and probably the largest I've taken on, is moving my family to Puerto Rico. I visited the island for the first time for a family vacation in 2008. I was smitten by the beautiful environment, extraordinary weather, and lively culture. Since then, moving to Puerto Rico has been a dream of mine, typically reserved for daydreams about retirement. In mid-2024, when seeking a change from my then-employer, I pursued remote work opportunities with the intention of moving... somewhere. When I found a remote job for a company headquartered in Santurce, my daydreams came within reach. Why wait for retirement to move to an island paradise? Our preparations are nearly complete and the adventure starts for real in June!
+My main project right now, and probably the largest I've taken on, is moving my family to Puerto Rico. I visited the island for the first time for a family vacation in 2008. I was smitten by the beautiful environment, extraordinary weather, and lively culture. Since then, moving to Puerto Rico has been a dream of mine, typically reserved for daydreams about retirement. In mid-2024, when seeking a change from my then-employer, I pursued remote work opportunities with the intention of moving... somewhere. When I found a remote job for a company headquartered in [Santurce](https://en.wikipedia.org/wiki/Santurce,_San_Juan,_Puerto_Rico), my daydreams came within reach. Why wait for retirement to move to an island paradise? Our preparations are nearly complete and the adventure starts for real in June!
 
 ### Homelab
 
 My homelab currently consists of 11 ThinkCentre Tiny PCs running Debian and k3s, a QNAP NAS, and Mikrotik routing and switching. The lab is mostly a way to learn and experiment with new technology, but I also operate services like [Jellyfin](https://github.com/jellyfin/jellyfin), [Mealie](https://github.com/mealie/mealie), and [Uptime Kuma](https://github.com/uptimekuma/uptimekume) for myself and my family.
+
+## Reading
+
+### History
+
+I'm currently reading [The Oxford History Of Greece And The Hellenistic World](https://academic.oup.com/book/51897). I've read several of the Oxford histories recently ([Medieval Europe](https://academic.oup.com/book/47840) is great) and really enjoyed them. I'm mostly familiar with the Platonic dialogs, but have really enjoyed learning a bit about Homer. Maybe I'll read some greek myths or poetry next.
+
+### Fiction
+
+I just finished rereading [Mona Lisa Overdrive](https://en.wikipedia.org/wiki/Mona_Lisa_Overdrive) by [William Gibson](https://bsky.app/profile/greatdismal.bsky.social). I'd read it before, but still really enjoyed it. [Sally Shears](https://williamgibson.fandom.com/wiki/Molly_Millions) is such a fun character. I haven't picked up my next fiction read yet. Maybe I'll read the next Wheel of Time book (I'm pretty sure I was last reading The Dragon Reborn, but I'm not sure that I finished it) or a continue with the [Mistborn books](https://mistborn.fandom.com/wiki/Hero_of_Ages).


### PR DESCRIPTION
This pull request introduces updates to the website content and configurations, including new pages, enhancements to existing pages, and minor configuration changes. The most significant changes involve the addition of a new blog post, updates to slash pages, and improvements to content organization.

### Website Content Updates:

* **New Blog Post**: Added a draft blog post titled "Updates" that discusses recent website changes, thoughts on simplification, and plans for future improvements, including CDN configuration and webmentions. (`site/content/posts/2025/updates/index.md`)

* **New Slash Page**: Created a `/chipotle` page documenting preferred orders at Chipotle and Subway, with detailed menu item lists for each. (`site/content/slashes/chipotle/index.md`)

### Enhancements to Existing Pages:

* **Slash Page Updates**: Revised the `/now` page to include new sections on reading preferences and updated the "Moving to Puerto Rico" section with a hyperlink to Santurce for better context. (`site/content/slashes/now/index.md`)

### Configuration Changes:

* **Markdownlint Configuration**: Updated `.markdownlint-cli2.yaml` to disable the `no-bare-urls` rule, allowing bare URLs in markdown files. (`.markdownlint-cli2.yaml`)